### PR TITLE
New feature add spacePadding

### DIFF
--- a/play/index.js
+++ b/play/index.js
@@ -2,8 +2,8 @@
 
 import Vue from "vue"
 import { play } from "vue-play"
-import Carousel from "../../../Desktop/vue-carousel/src/Carousel.vue"
-import Slide from "../../../Desktop/vue-carousel/src/Slide.vue"
+import Carousel from "../src/Carousel.vue"
+import Slide from "../src/Slide.vue"
 
 const containerWidth = 500;
 const images = [

--- a/play/index.js
+++ b/play/index.js
@@ -2,8 +2,8 @@
 
 import Vue from "vue"
 import { play } from "vue-play"
-import Carousel from "../src/Carousel.vue"
-import Slide from "../src/Slide.vue"
+import Carousel from "../../../Desktop/vue-carousel/src/Carousel.vue"
+import Slide from "../../../Desktop/vue-carousel/src/Slide.vue"
 
 const containerWidth = 500;
 const images = [
@@ -136,4 +136,8 @@ play("Carousel", module)
       },
     }
   })
+    .add("with spacePadding 100px", h => createContainer(
+        h, containerWidth, [h(Carousel, { props: { spacePadding: 100, perPage: 1} }, generateSlideImages(h))]
+        )
+    )
 

--- a/src/Carousel.vue
+++ b/src/Carousel.vue
@@ -7,7 +7,9 @@
           transform: translateX(${currentOffset}px);
           transition: ${transitionStyle};
           flex-basis: ${slideWidth}px;
-          visibility: ${slideWidth ? 'visible' : 'hidden'}
+          visibility: ${slideWidth ? 'visible' : 'hidden'};
+          padding-left: ${padding}px;
+          padding-right: ${padding}px;
         `"
       >
         <slot></slot>
@@ -50,7 +52,7 @@
         dragOffset: 0,
         dragStartX: 0,
         mousedown: false,
-        slideCount: 0
+        slideCount: 0,
       }
     },
     mixins: [
@@ -179,6 +181,13 @@
         type: Boolean,
         default: false,
       },
+      /**
+       *  Stage padding option adds left and right padding style (in pixels) onto VueCarousel-inner.
+       */
+      spacePadding: {
+        type: Number,
+        default: 0,
+      }
     },
     computed: {
       /**
@@ -273,13 +282,18 @@
        * @return {Number} Slide width
        */
       slideWidth() {
-        const width = this.carouselWidth
+        const width = this.carouselWidth - (this.spacePadding * 2)
         const perPage = this.currentPerPage
 
         return width / perPage
       },
       transitionStyle() {
         return `${this.speed / 1000}s ${this.easing} transform`
+      },
+
+      padding() {
+        const padding = this.spacePadding
+        return (padding > 0) ? padding : false
       },
     },
     methods: {

--- a/src/Carousel.vue
+++ b/src/Carousel.vue
@@ -290,7 +290,6 @@
       transitionStyle() {
         return `${this.speed / 1000}s ${this.easing} transform`
       },
-
       padding() {
         const padding = this.spacePadding
         return (padding > 0) ? padding : false


### PR DESCRIPTION
New feature that adds new space padding. 
# How to use
New param where we can add a value in pixels. This will add padding left and right to show other slides. 

:spacePadding='50' 


# Examples
## spacePadding 100px and one slide per page
![statepadding-100px-one-per-page](https://user-images.githubusercontent.com/6005590/33929582-4db40054-dfea-11e7-8e72-364f6c1fcb39.gif)

## spacePadding 50px and three slide per page
![statepadding-100px-two-per-page](https://user-images.githubusercontent.com/6005590/33929583-4dceac4c-dfea-11e7-9efe-76677bde9eaa.gif)

## spacePadding 50px and three slide per page
![statepadding-50px-three-per-page](https://user-images.githubusercontent.com/6005590/33929581-4d91e2d0-dfea-11e7-9b10-2f1fe6fdf12b.gif)

