### PR TITLE
chore(examples): updated examples

### DIFF
--- a/docs/source/examples/index.md
+++ b/docs/source/examples/index.md
@@ -13,13 +13,19 @@ No options configured, 10 slides added to the carousel.
 Configured breakpoints: 2 slides on mobile (<= 480px), 3 slides on tablet (<= 768).
 **Note: in a JSFiddle iframe, the breakpoint is determined by the iframe's width.**
 
-<script async src="//jsfiddle.net/toddlawton/rvhxLdkq/embed/result,js/"></script>
+<script async src="//jsfiddle.net/quinnssense/bojn4dz4/embed/js,result/"></script>
 
 ## Scroll per page
 
-Instead of scrolling on a per item basis, the carousel will scroll the configured [perPage](/vue-carousel/api#perPage) or [perPageCustom](/vue-carousel/api#perPageCustom) with each movement.
+Instead of scrolling on a per item basis, the carousel will scroll the configured [perPage](/vue-carousel/api#perPage) with each movement.
 
 <script async src="//jsfiddle.net/toddlawton/6ckc1pqv/embed/result,js/"></script>
+
+## Scroll per page (custom)
+
+Instead of scrolling on a per item basis, the carousel will scroll the configured by [perPageCustom](/vue-carousel/api#perPageCustom) with each movement.
+
+<script async src="//jsfiddle.net/quinnssense/gjr7wbph/1/embed/"></script></script>
 
 ## Autoplay
 


### PR DESCRIPTION
Updated documentation examples to clarify the required props for `:perPage`.