### PR TITLE
docs: change 'autoplayHoverPause' default: true

### DIFF
--- a/docs/source/api/index.md
+++ b/docs/source/api/index.md
@@ -23,7 +23,7 @@ Time elapsed before advancing slide
 Flag to pause autoplay on hover
 
 * **Type**: `Boolean`
-* **Default**: `false`
+* **Default**: `true`
 
 ### loop
 


### PR DESCRIPTION
February 14, 2017 'autoplayHoverPause' default value was changed to 'true' in commit 30e60cd. But the documentation wasn't updated.