### PR TITLE
fix(wrapper): Return wrapper class to related block

### DIFF
--- a/docs/source/api/index.md
+++ b/docs/source/api/index.md
@@ -23,7 +23,7 @@ Time elapsed before advancing slide
 Flag to pause autoplay on hover
 
 * **Type**: `Boolean`
-* **Default**: `false`
+* **Default**: `true`
 
 ### loop
 

--- a/src/Carousel.vue
+++ b/src/Carousel.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="VueCarousel">
-    <div ref="VueCarousel-wrapper">
+    <div class="VueCarousel-wrapper" ref="VueCarousel-wrapper">
       <div
         class="VueCarousel-inner"
         v-bind:style="`

--- a/tests/client/components/__snapshots__/carousel.spec.js.snap
+++ b/tests/client/components/__snapshots__/carousel.spec.js.snap
@@ -1,185 +1,185 @@
 exports[`Carousel should apply custom slides per page when responsive param provided 1`] = `
-"div
+".VueCarousel-wrapper
   .VueCarousel-inner(style=\'visibility: hidden;\')
-// 
-// 
+//
+//
 "
 `;
 
 exports[`Carousel should apply default carousel width when element has 0 width 1`] = `
-"div
+".VueCarousel-wrapper
   .VueCarousel-inner(style=\'visibility: hidden;\')
-// 
-// 
+//
+//
 "
 `;
 
 exports[`Carousel should be unable to advance backward by default 1`] = `
-"div
+".VueCarousel-wrapper
   .VueCarousel-inner(style=\'visibility: hidden;\')
-// 
-// 
+//
+//
 "
 `;
 
 exports[`Carousel should be unable to advance forward by default (no slides added) 1`] = `
-"div
+".VueCarousel-wrapper
   .VueCarousel-inner(style=\'visibility: hidden;\')
-// 
-// 
+//
+//
 "
 `;
 
 exports[`Carousel should begin autoplaying when option specified 1`] = `
-"div
+".VueCarousel-wrapper
   .VueCarousel-inner(style=\'visibility: hidden;\')
     .VueCarousel-slide
     .VueCarousel-slide
-|  
+|
 .VueCarousel-pagination
   .VueCarousel-dot-container
     .VueCarousel-dot.VueCarousel-dot--active(style=\'margin-top: 20px; padding: 10px;\')
       .VueCarousel-dot-inner(style=\'width: 10px; height: 10px; background: rgb(0, 0, 0);\')
     .VueCarousel-dot(style=\'margin-top: 20px; padding: 10px;\')
       .VueCarousel-dot-inner(style=\'width: 10px; height: 10px; background: rgb(239, 239, 239);\')
-// 
+//
 "
 `;
 
 exports[`Carousel should decrease current slide number by 1 when advance page backward is called 1`] = `
-"div
+".VueCarousel-wrapper
   .VueCarousel-inner(style=\'visibility: hidden;\')
     .VueCarousel-slide
     .VueCarousel-slide
-|  
+|
 .VueCarousel-pagination
   .VueCarousel-dot-container
     .VueCarousel-dot(style=\'margin-top: 20px; padding: 10px;\')
       .VueCarousel-dot-inner(style=\'width: 10px; height: 10px; background: rgb(239, 239, 239);\')
     .VueCarousel-dot.VueCarousel-dot--active(style=\'margin-top: 20px; padding: 10px;\')
       .VueCarousel-dot-inner(style=\'width: 10px; height: 10px; background: rgb(0, 0, 0);\')
-// 
+//
 "
 `;
 
 exports[`Carousel should fall back to default slides per page when no responsive param provided 1`] = `
-"div
+".VueCarousel-wrapper
   .VueCarousel-inner(style=\'visibility: hidden;\')
     .VueCarousel-slide
     .VueCarousel-slide
     .VueCarousel-slide
-|  
+|
 .VueCarousel-pagination
   .VueCarousel-dot-container
     .VueCarousel-dot.VueCarousel-dot--active(style=\'margin-top: 20px; padding: 10px;\')
       .VueCarousel-dot-inner(style=\'width: 10px; height: 10px; background: rgb(0, 0, 0);\')
     .VueCarousel-dot(style=\'margin-top: 20px; padding: 10px;\')
       .VueCarousel-dot-inner(style=\'width: 10px; height: 10px; background: rgb(239, 239, 239);\')
-// 
+//
 "
 `;
 
 exports[`Carousel should increase current slide number by 1 when advance page is called 1`] = `
-"div
+".VueCarousel-wrapper
   .VueCarousel-inner(style=\'visibility: hidden;\')
     .VueCarousel-slide
     .VueCarousel-slide
-|  
+|
 .VueCarousel-pagination
   .VueCarousel-dot-container
     .VueCarousel-dot(style=\'margin-top: 20px; padding: 10px;\')
       .VueCarousel-dot-inner(style=\'width: 10px; height: 10px; background: rgb(239, 239, 239);\')
     .VueCarousel-dot.VueCarousel-dot--active(style=\'margin-top: 20px; padding: 10px;\')
       .VueCarousel-dot-inner(style=\'width: 10px; height: 10px; background: rgb(0, 0, 0);\')
-// 
+//
 "
 `;
 
 exports[`Carousel should increase current slide number by 1 when advance page is called with a non "backward" argument 1`] = `
-"div
+".VueCarousel-wrapper
   .VueCarousel-inner(style=\'visibility: hidden;\')
     .VueCarousel-slide
     .VueCarousel-slide
-|  
+|
 .VueCarousel-pagination
   .VueCarousel-dot-container
     .VueCarousel-dot(style=\'margin-top: 20px; padding: 10px;\')
       .VueCarousel-dot-inner(style=\'width: 10px; height: 10px; background: rgb(239, 239, 239);\')
     .VueCarousel-dot.VueCarousel-dot--active(style=\'margin-top: 20px; padding: 10px;\')
       .VueCarousel-dot-inner(style=\'width: 10px; height: 10px; background: rgb(0, 0, 0);\')
-// 
+//
 "
 `;
 
 exports[`Carousel should loop back to the start when loop is true and advance page non "backward" is called from the last page 1`] = `
-"div
+".VueCarousel-wrapper
   .VueCarousel-inner(style=\'visibility: hidden;\')
     .VueCarousel-slide
     .VueCarousel-slide
-|  
+|
 .VueCarousel-pagination
   .VueCarousel-dot-container
     .VueCarousel-dot.VueCarousel-dot--active(style=\'margin-top: 20px; padding: 10px;\')
       .VueCarousel-dot-inner(style=\'width: 10px; height: 10px; background: rgb(0, 0, 0);\')
     .VueCarousel-dot(style=\'margin-top: 20px; padding: 10px;\')
       .VueCarousel-dot-inner(style=\'width: 10px; height: 10px; background: rgb(239, 239, 239);\')
-// 
+//
 "
 `;
 
 exports[`Carousel should loop to the end when loop is true and advance page "backward" is called from the first page 1`] = `
-"div
+".VueCarousel-wrapper
   .VueCarousel-inner(style=\'visibility: hidden;\')
     .VueCarousel-slide
     .VueCarousel-slide
-|  
+|
 .VueCarousel-pagination
   .VueCarousel-dot-container
     .VueCarousel-dot(style=\'margin-top: 20px; padding: 10px;\')
       .VueCarousel-dot-inner(style=\'width: 10px; height: 10px; background: rgb(239, 239, 239);\')
     .VueCarousel-dot.VueCarousel-dot--active(style=\'margin-top: 20px; padding: 10px;\')
       .VueCarousel-dot-inner(style=\'width: 10px; height: 10px; background: rgb(0, 0, 0);\')
-// 
+//
 "
 `;
 
 exports[`Carousel should mount successfully 1`] = `
-"div
+".VueCarousel-wrapper
   .VueCarousel-inner(style=\'visibility: hidden;\')
-// 
-// 
+//
+//
 "
 `;
 
 exports[`Carousel should register 0 slides when 0 slides are added to the slots 1`] = `
-"div
+".VueCarousel-wrapper
   .VueCarousel-inner(style=\'visibility: hidden;\')
-// 
-// 
+//
+//
 "
 `;
 
 exports[`Carousel should register 3 slides when 3 slides are added to the slots 1`] = `
-"div
+".VueCarousel-wrapper
   .VueCarousel-inner(style=\'visibility: hidden;\')
     .VueCarousel-slide
     .VueCarousel-slide
     .VueCarousel-slide
-|  
+|
 .VueCarousel-pagination
   .VueCarousel-dot-container
     .VueCarousel-dot.VueCarousel-dot--active(style=\'margin-top: 20px; padding: 10px;\')
       .VueCarousel-dot-inner(style=\'width: 10px; height: 10px; background: rgb(0, 0, 0);\')
     .VueCarousel-dot(style=\'margin-top: 20px; padding: 10px;\')
       .VueCarousel-dot-inner(style=\'width: 10px; height: 10px; background: rgb(239, 239, 239);\')
-// 
+//
 "
 `;
 
 exports[`Carousel should unmount successfully 1`] = `
-"div
+".VueCarousel-wrapper
   .VueCarousel-inner(style=\'visibility: hidden;\')
-// 
-// 
+//
+//
 "
 `;

--- a/tests/client/components/__snapshots__/carousel.spec.js.snap
+++ b/tests/client/components/__snapshots__/carousel.spec.js.snap
@@ -1,32 +1,32 @@
 exports[`Carousel should apply custom slides per page when responsive param provided 1`] = `
 ".VueCarousel-wrapper
   .VueCarousel-inner(style=\'visibility: hidden;\')
-//
-//
+// 
+// 
 "
 `;
 
 exports[`Carousel should apply default carousel width when element has 0 width 1`] = `
 ".VueCarousel-wrapper
   .VueCarousel-inner(style=\'visibility: hidden;\')
-//
-//
+// 
+// 
 "
 `;
 
 exports[`Carousel should be unable to advance backward by default 1`] = `
 ".VueCarousel-wrapper
   .VueCarousel-inner(style=\'visibility: hidden;\')
-//
-//
+// 
+// 
 "
 `;
 
 exports[`Carousel should be unable to advance forward by default (no slides added) 1`] = `
 ".VueCarousel-wrapper
   .VueCarousel-inner(style=\'visibility: hidden;\')
-//
-//
+// 
+// 
 "
 `;
 
@@ -35,14 +35,14 @@ exports[`Carousel should begin autoplaying when option specified 1`] = `
   .VueCarousel-inner(style=\'visibility: hidden;\')
     .VueCarousel-slide
     .VueCarousel-slide
-|
+|  
 .VueCarousel-pagination
   .VueCarousel-dot-container
     .VueCarousel-dot.VueCarousel-dot--active(style=\'margin-top: 20px; padding: 10px;\')
       .VueCarousel-dot-inner(style=\'width: 10px; height: 10px; background: rgb(0, 0, 0);\')
     .VueCarousel-dot(style=\'margin-top: 20px; padding: 10px;\')
       .VueCarousel-dot-inner(style=\'width: 10px; height: 10px; background: rgb(239, 239, 239);\')
-//
+// 
 "
 `;
 
@@ -51,14 +51,14 @@ exports[`Carousel should decrease current slide number by 1 when advance page ba
   .VueCarousel-inner(style=\'visibility: hidden;\')
     .VueCarousel-slide
     .VueCarousel-slide
-|
+|  
 .VueCarousel-pagination
   .VueCarousel-dot-container
     .VueCarousel-dot(style=\'margin-top: 20px; padding: 10px;\')
       .VueCarousel-dot-inner(style=\'width: 10px; height: 10px; background: rgb(239, 239, 239);\')
     .VueCarousel-dot.VueCarousel-dot--active(style=\'margin-top: 20px; padding: 10px;\')
       .VueCarousel-dot-inner(style=\'width: 10px; height: 10px; background: rgb(0, 0, 0);\')
-//
+// 
 "
 `;
 
@@ -68,14 +68,14 @@ exports[`Carousel should fall back to default slides per page when no responsive
     .VueCarousel-slide
     .VueCarousel-slide
     .VueCarousel-slide
-|
+|  
 .VueCarousel-pagination
   .VueCarousel-dot-container
     .VueCarousel-dot.VueCarousel-dot--active(style=\'margin-top: 20px; padding: 10px;\')
       .VueCarousel-dot-inner(style=\'width: 10px; height: 10px; background: rgb(0, 0, 0);\')
     .VueCarousel-dot(style=\'margin-top: 20px; padding: 10px;\')
       .VueCarousel-dot-inner(style=\'width: 10px; height: 10px; background: rgb(239, 239, 239);\')
-//
+// 
 "
 `;
 
@@ -84,14 +84,14 @@ exports[`Carousel should increase current slide number by 1 when advance page is
   .VueCarousel-inner(style=\'visibility: hidden;\')
     .VueCarousel-slide
     .VueCarousel-slide
-|
+|  
 .VueCarousel-pagination
   .VueCarousel-dot-container
     .VueCarousel-dot(style=\'margin-top: 20px; padding: 10px;\')
       .VueCarousel-dot-inner(style=\'width: 10px; height: 10px; background: rgb(239, 239, 239);\')
     .VueCarousel-dot.VueCarousel-dot--active(style=\'margin-top: 20px; padding: 10px;\')
       .VueCarousel-dot-inner(style=\'width: 10px; height: 10px; background: rgb(0, 0, 0);\')
-//
+// 
 "
 `;
 
@@ -100,14 +100,14 @@ exports[`Carousel should increase current slide number by 1 when advance page is
   .VueCarousel-inner(style=\'visibility: hidden;\')
     .VueCarousel-slide
     .VueCarousel-slide
-|
+|  
 .VueCarousel-pagination
   .VueCarousel-dot-container
     .VueCarousel-dot(style=\'margin-top: 20px; padding: 10px;\')
       .VueCarousel-dot-inner(style=\'width: 10px; height: 10px; background: rgb(239, 239, 239);\')
     .VueCarousel-dot.VueCarousel-dot--active(style=\'margin-top: 20px; padding: 10px;\')
       .VueCarousel-dot-inner(style=\'width: 10px; height: 10px; background: rgb(0, 0, 0);\')
-//
+// 
 "
 `;
 
@@ -116,14 +116,14 @@ exports[`Carousel should loop back to the start when loop is true and advance pa
   .VueCarousel-inner(style=\'visibility: hidden;\')
     .VueCarousel-slide
     .VueCarousel-slide
-|
+|  
 .VueCarousel-pagination
   .VueCarousel-dot-container
     .VueCarousel-dot.VueCarousel-dot--active(style=\'margin-top: 20px; padding: 10px;\')
       .VueCarousel-dot-inner(style=\'width: 10px; height: 10px; background: rgb(0, 0, 0);\')
     .VueCarousel-dot(style=\'margin-top: 20px; padding: 10px;\')
       .VueCarousel-dot-inner(style=\'width: 10px; height: 10px; background: rgb(239, 239, 239);\')
-//
+// 
 "
 `;
 
@@ -132,30 +132,30 @@ exports[`Carousel should loop to the end when loop is true and advance page "bac
   .VueCarousel-inner(style=\'visibility: hidden;\')
     .VueCarousel-slide
     .VueCarousel-slide
-|
+|  
 .VueCarousel-pagination
   .VueCarousel-dot-container
     .VueCarousel-dot(style=\'margin-top: 20px; padding: 10px;\')
       .VueCarousel-dot-inner(style=\'width: 10px; height: 10px; background: rgb(239, 239, 239);\')
     .VueCarousel-dot.VueCarousel-dot--active(style=\'margin-top: 20px; padding: 10px;\')
       .VueCarousel-dot-inner(style=\'width: 10px; height: 10px; background: rgb(0, 0, 0);\')
-//
+// 
 "
 `;
 
 exports[`Carousel should mount successfully 1`] = `
 ".VueCarousel-wrapper
   .VueCarousel-inner(style=\'visibility: hidden;\')
-//
-//
+// 
+// 
 "
 `;
 
 exports[`Carousel should register 0 slides when 0 slides are added to the slots 1`] = `
 ".VueCarousel-wrapper
   .VueCarousel-inner(style=\'visibility: hidden;\')
-//
-//
+// 
+// 
 "
 `;
 
@@ -165,21 +165,21 @@ exports[`Carousel should register 3 slides when 3 slides are added to the slots 
     .VueCarousel-slide
     .VueCarousel-slide
     .VueCarousel-slide
-|
+|  
 .VueCarousel-pagination
   .VueCarousel-dot-container
     .VueCarousel-dot.VueCarousel-dot--active(style=\'margin-top: 20px; padding: 10px;\')
       .VueCarousel-dot-inner(style=\'width: 10px; height: 10px; background: rgb(0, 0, 0);\')
     .VueCarousel-dot(style=\'margin-top: 20px; padding: 10px;\')
       .VueCarousel-dot-inner(style=\'width: 10px; height: 10px; background: rgb(239, 239, 239);\')
-//
+// 
 "
 `;
 
 exports[`Carousel should unmount successfully 1`] = `
 ".VueCarousel-wrapper
   .VueCarousel-inner(style=\'visibility: hidden;\')
-//
-//
+// 
+// 
 "
 `;

--- a/tests/client/components/__snapshots__/navigation.spec.js.snap
+++ b/tests/client/components/__snapshots__/navigation.spec.js.snap
@@ -3,17 +3,17 @@ exports[`Navigation should mount successfully 1`] = `
   .VueCarousel-inner(style=\'visibility: hidden;\')
     .VueCarousel-slide
     .VueCarousel-slide
-|
+|  
 .VueCarousel-pagination
   .VueCarousel-dot-container
     .VueCarousel-dot.VueCarousel-dot--active(style=\'margin-top: 20px; padding: 10px;\')
       .VueCarousel-dot-inner(style=\'width: 10px; height: 10px; background: rgb(0, 0, 0);\')
     .VueCarousel-dot(style=\'margin-top: 20px; padding: 10px;\')
       .VueCarousel-dot-inner(style=\'width: 10px; height: 10px; background: rgb(239, 239, 239);\')
-|
+|  
 .VueCarousel-navigation
   a.VueCarousel-navigation-button.VueCarousel-navigation-prev.VueCarousel-navigation--disabled(href=\'#\', style=\'padding: 8px; margin-right: -8px;\') &#x25C0;
-  |
+  |  
   a.VueCarousel-navigation-button.VueCarousel-navigation-next(href=\'#\', style=\'padding: 8px; margin-left: -8px;\') &#x25B6;
 "
 `;
@@ -23,17 +23,17 @@ exports[`Navigation should render a next button 1`] = `
   .VueCarousel-inner(style=\'visibility: hidden;\')
     .VueCarousel-slide
     .VueCarousel-slide
-|
+|  
 .VueCarousel-pagination
   .VueCarousel-dot-container
     .VueCarousel-dot.VueCarousel-dot--active(style=\'margin-top: 20px; padding: 10px;\')
       .VueCarousel-dot-inner(style=\'width: 10px; height: 10px; background: rgb(0, 0, 0);\')
     .VueCarousel-dot(style=\'margin-top: 20px; padding: 10px;\')
       .VueCarousel-dot-inner(style=\'width: 10px; height: 10px; background: rgb(239, 239, 239);\')
-|
+|  
 .VueCarousel-navigation
   a.VueCarousel-navigation-button.VueCarousel-navigation-prev.VueCarousel-navigation--disabled(href=\'#\', style=\'padding: 8px; margin-right: -8px;\') &#x25C0;
-  |
+  |  
   a.VueCarousel-navigation-button.VueCarousel-navigation-next(href=\'#\', style=\'padding: 8px; margin-left: -8px;\') &#x25B6;
 "
 `;
@@ -43,17 +43,17 @@ exports[`Navigation should render a prev button 1`] = `
   .VueCarousel-inner(style=\'visibility: hidden;\')
     .VueCarousel-slide
     .VueCarousel-slide
-|
+|  
 .VueCarousel-pagination
   .VueCarousel-dot-container
     .VueCarousel-dot.VueCarousel-dot--active(style=\'margin-top: 20px; padding: 10px;\')
       .VueCarousel-dot-inner(style=\'width: 10px; height: 10px; background: rgb(0, 0, 0);\')
     .VueCarousel-dot(style=\'margin-top: 20px; padding: 10px;\')
       .VueCarousel-dot-inner(style=\'width: 10px; height: 10px; background: rgb(239, 239, 239);\')
-|
+|  
 .VueCarousel-navigation
   a.VueCarousel-navigation-button.VueCarousel-navigation-prev.VueCarousel-navigation--disabled(href=\'#\', style=\'padding: 8px; margin-right: -8px;\') &#x25C0;
-  |
+  |  
   a.VueCarousel-navigation-button.VueCarousel-navigation-next(href=\'#\', style=\'padding: 8px; margin-left: -8px;\') &#x25B6;
 "
 `;
@@ -63,17 +63,17 @@ exports[`Navigation should trigger page advance backward when prev is clicked 1`
   .VueCarousel-inner(style=\'visibility: hidden;\')
     .VueCarousel-slide
     .VueCarousel-slide
-|
+|  
 .VueCarousel-pagination
   .VueCarousel-dot-container
     .VueCarousel-dot(style=\'margin-top: 20px; padding: 10px;\')
       .VueCarousel-dot-inner(style=\'width: 10px; height: 10px; background: rgb(239, 239, 239);\')
     .VueCarousel-dot.VueCarousel-dot--active(style=\'margin-top: 20px; padding: 10px;\')
       .VueCarousel-dot-inner(style=\'width: 10px; height: 10px; background: rgb(0, 0, 0);\')
-|
+|  
 .VueCarousel-navigation
   a.VueCarousel-navigation-button.VueCarousel-navigation-prev(href=\'#\', style=\'padding: 8px; margin-right: -8px;\') &#x25C0;
-  |
+  |  
   a.VueCarousel-navigation-button.VueCarousel-navigation-next.VueCarousel-navigation--disabled(href=\'#\', style=\'padding: 8px; margin-left: -8px;\') &#x25B6;
 "
 `;
@@ -83,17 +83,17 @@ exports[`Navigation should trigger page advance when next is clicked 1`] = `
   .VueCarousel-inner(style=\'visibility: hidden;\')
     .VueCarousel-slide
     .VueCarousel-slide
-|
+|  
 .VueCarousel-pagination
   .VueCarousel-dot-container
     .VueCarousel-dot(style=\'margin-top: 20px; padding: 10px;\')
       .VueCarousel-dot-inner(style=\'width: 10px; height: 10px; background: rgb(239, 239, 239);\')
     .VueCarousel-dot.VueCarousel-dot--active(style=\'margin-top: 20px; padding: 10px;\')
       .VueCarousel-dot-inner(style=\'width: 10px; height: 10px; background: rgb(0, 0, 0);\')
-|
+|  
 .VueCarousel-navigation
   a.VueCarousel-navigation-button.VueCarousel-navigation-prev(href=\'#\', style=\'padding: 8px; margin-right: -8px;\') &#x25C0;
-  |
+  |  
   a.VueCarousel-navigation-button.VueCarousel-navigation-next.VueCarousel-navigation--disabled(href=\'#\', style=\'padding: 8px; margin-left: -8px;\') &#x25B6;
 "
 `;

--- a/tests/client/components/__snapshots__/navigation.spec.js.snap
+++ b/tests/client/components/__snapshots__/navigation.spec.js.snap
@@ -1,99 +1,99 @@
 exports[`Navigation should mount successfully 1`] = `
-"div
+".VueCarousel-wrapper
   .VueCarousel-inner(style=\'visibility: hidden;\')
     .VueCarousel-slide
     .VueCarousel-slide
-|  
+|
 .VueCarousel-pagination
   .VueCarousel-dot-container
     .VueCarousel-dot.VueCarousel-dot--active(style=\'margin-top: 20px; padding: 10px;\')
       .VueCarousel-dot-inner(style=\'width: 10px; height: 10px; background: rgb(0, 0, 0);\')
     .VueCarousel-dot(style=\'margin-top: 20px; padding: 10px;\')
       .VueCarousel-dot-inner(style=\'width: 10px; height: 10px; background: rgb(239, 239, 239);\')
-|  
+|
 .VueCarousel-navigation
   a.VueCarousel-navigation-button.VueCarousel-navigation-prev.VueCarousel-navigation--disabled(href=\'#\', style=\'padding: 8px; margin-right: -8px;\') &#x25C0;
-  |  
+  |
   a.VueCarousel-navigation-button.VueCarousel-navigation-next(href=\'#\', style=\'padding: 8px; margin-left: -8px;\') &#x25B6;
 "
 `;
 
 exports[`Navigation should render a next button 1`] = `
-"div
+".VueCarousel-wrapper
   .VueCarousel-inner(style=\'visibility: hidden;\')
     .VueCarousel-slide
     .VueCarousel-slide
-|  
+|
 .VueCarousel-pagination
   .VueCarousel-dot-container
     .VueCarousel-dot.VueCarousel-dot--active(style=\'margin-top: 20px; padding: 10px;\')
       .VueCarousel-dot-inner(style=\'width: 10px; height: 10px; background: rgb(0, 0, 0);\')
     .VueCarousel-dot(style=\'margin-top: 20px; padding: 10px;\')
       .VueCarousel-dot-inner(style=\'width: 10px; height: 10px; background: rgb(239, 239, 239);\')
-|  
+|
 .VueCarousel-navigation
   a.VueCarousel-navigation-button.VueCarousel-navigation-prev.VueCarousel-navigation--disabled(href=\'#\', style=\'padding: 8px; margin-right: -8px;\') &#x25C0;
-  |  
+  |
   a.VueCarousel-navigation-button.VueCarousel-navigation-next(href=\'#\', style=\'padding: 8px; margin-left: -8px;\') &#x25B6;
 "
 `;
 
 exports[`Navigation should render a prev button 1`] = `
-"div
+".VueCarousel-wrapper
   .VueCarousel-inner(style=\'visibility: hidden;\')
     .VueCarousel-slide
     .VueCarousel-slide
-|  
+|
 .VueCarousel-pagination
   .VueCarousel-dot-container
     .VueCarousel-dot.VueCarousel-dot--active(style=\'margin-top: 20px; padding: 10px;\')
       .VueCarousel-dot-inner(style=\'width: 10px; height: 10px; background: rgb(0, 0, 0);\')
     .VueCarousel-dot(style=\'margin-top: 20px; padding: 10px;\')
       .VueCarousel-dot-inner(style=\'width: 10px; height: 10px; background: rgb(239, 239, 239);\')
-|  
+|
 .VueCarousel-navigation
   a.VueCarousel-navigation-button.VueCarousel-navigation-prev.VueCarousel-navigation--disabled(href=\'#\', style=\'padding: 8px; margin-right: -8px;\') &#x25C0;
-  |  
+  |
   a.VueCarousel-navigation-button.VueCarousel-navigation-next(href=\'#\', style=\'padding: 8px; margin-left: -8px;\') &#x25B6;
 "
 `;
 
 exports[`Navigation should trigger page advance backward when prev is clicked 1`] = `
-"div
+".VueCarousel-wrapper
   .VueCarousel-inner(style=\'visibility: hidden;\')
     .VueCarousel-slide
     .VueCarousel-slide
-|  
+|
 .VueCarousel-pagination
   .VueCarousel-dot-container
     .VueCarousel-dot(style=\'margin-top: 20px; padding: 10px;\')
       .VueCarousel-dot-inner(style=\'width: 10px; height: 10px; background: rgb(239, 239, 239);\')
     .VueCarousel-dot.VueCarousel-dot--active(style=\'margin-top: 20px; padding: 10px;\')
       .VueCarousel-dot-inner(style=\'width: 10px; height: 10px; background: rgb(0, 0, 0);\')
-|  
+|
 .VueCarousel-navigation
   a.VueCarousel-navigation-button.VueCarousel-navigation-prev(href=\'#\', style=\'padding: 8px; margin-right: -8px;\') &#x25C0;
-  |  
+  |
   a.VueCarousel-navigation-button.VueCarousel-navigation-next.VueCarousel-navigation--disabled(href=\'#\', style=\'padding: 8px; margin-left: -8px;\') &#x25B6;
 "
 `;
 
 exports[`Navigation should trigger page advance when next is clicked 1`] = `
-"div
+".VueCarousel-wrapper
   .VueCarousel-inner(style=\'visibility: hidden;\')
     .VueCarousel-slide
     .VueCarousel-slide
-|  
+|
 .VueCarousel-pagination
   .VueCarousel-dot-container
     .VueCarousel-dot(style=\'margin-top: 20px; padding: 10px;\')
       .VueCarousel-dot-inner(style=\'width: 10px; height: 10px; background: rgb(239, 239, 239);\')
     .VueCarousel-dot.VueCarousel-dot--active(style=\'margin-top: 20px; padding: 10px;\')
       .VueCarousel-dot-inner(style=\'width: 10px; height: 10px; background: rgb(0, 0, 0);\')
-|  
+|
 .VueCarousel-navigation
   a.VueCarousel-navigation-button.VueCarousel-navigation-prev(href=\'#\', style=\'padding: 8px; margin-right: -8px;\') &#x25C0;
-  |  
+  |
   a.VueCarousel-navigation-button.VueCarousel-navigation-next.VueCarousel-navigation--disabled(href=\'#\', style=\'padding: 8px; margin-left: -8px;\') &#x25B6;
 "
 `;

--- a/tests/client/components/__snapshots__/slide.spec.js.snap
+++ b/tests/client/components/__snapshots__/slide.spec.js.snap
@@ -2,11 +2,11 @@ exports[`Slide should mount successfully 1`] = `
 ".VueCarousel-wrapper
   .VueCarousel-inner(style=\'visibility: hidden;\')
     .VueCarousel-slide
-|
+|  
 .VueCarousel-pagination(style=\'display: none;\')
   .VueCarousel-dot-container
     .VueCarousel-dot.VueCarousel-dot--active(style=\'margin-top: 20px; padding: 10px;\')
       .VueCarousel-dot-inner(style=\'width: 10px; height: 10px; background: rgb(0, 0, 0);\')
-//
+// 
 "
 `;

--- a/tests/client/components/__snapshots__/slide.spec.js.snap
+++ b/tests/client/components/__snapshots__/slide.spec.js.snap
@@ -1,12 +1,12 @@
 exports[`Slide should mount successfully 1`] = `
-"div
+".VueCarousel-wrapper
   .VueCarousel-inner(style=\'visibility: hidden;\')
     .VueCarousel-slide
-|  
+|
 .VueCarousel-pagination(style=\'display: none;\')
   .VueCarousel-dot-container
     .VueCarousel-dot.VueCarousel-dot--active(style=\'margin-top: 20px; padding: 10px;\')
       .VueCarousel-dot-inner(style=\'width: 10px; height: 10px; background: rgb(0, 0, 0);\')
-// 
+//
 "
 `;


### PR DESCRIPTION
After 0.6.7 update you've introduced carousel wrapper ref but also removed its class from Carousel.vue component which results in all slides showing at the same time without wrapper's 'overflow: hidden' css property. This solves the problem.