### PR TITLE
Add vendor specific style prefixes (fixes IE10 support)

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  plugins: {
+    'autoprefixer': {}
+  }
+}

--- a/src/Carousel.vue
+++ b/src/Carousel.vue
@@ -6,6 +6,8 @@
         v-bind:style="`
           transform: translate3d(${currentOffset}px, 0, 0);
           transition: ${!dragging ? transitionStyle : 'none'};
+          ms-flex-preferred-size: ${slideWidth}px;
+          webkit-flex-basis: ${slideWidth}px;
           flex-basis: ${slideWidth}px;
           visibility: ${slideWidth ? 'visible' : 'hidden'};
           padding-left: ${padding}px;


### PR DESCRIPTION
This uses postcss's autoprefixer (vue-loader already pipes through postcss) to enable vendor prefixes, as well as setting the vendor prefixes on the v-bind style. I needed this for IE10 support.

Related: https://github.com/SSENSE/vue-carousel/issues/98