### PR TITLE
CarouselWidth should be the width of VueCarousel-inner

### DIFF
--- a/play/index.js
+++ b/play/index.js
@@ -220,22 +220,15 @@ play("Carousel", module)
   )
   .add("Custom width", {
     components: { Carousel, Slide },
-    mounted() {
-      const wrapper = this.$refs["customWidth"].$refs["VueCarousel-wrapper"]
-      wrapper.style.padding = "0 30px"
-      wrapper.style.boxSizing = "border-box"
-    },
     render: h => {
       return createContainer(
         h, containerWidth, [h(Carousel, {
-          ref: "customWidth",
+          props: {
+            perPage: 1,
+            spacePadding: 30
+          }
         }, [new Array(8).fill(0).map((item, index) => {
-          return h(Slide, {
-            style: {
-              padding: "0 10px",
-              boxSizing: "border-box"
-            }
-          }, [h("div", {
+          return h(Slide, {}, [h("div", {
             style: {
               width: "100%",
               height: "400px",

--- a/play/index.js
+++ b/play/index.js
@@ -218,3 +218,36 @@ play("Carousel", module)
       h, containerWidth, [h(Carousel, { props: { spacePadding: 100, perPage: 1} }, generateSlideImages(h))]
       )
   )
+  .add("Custom width", {
+    components: { Carousel, Slide },
+    mounted() {
+      const wrapper = this.$refs["customWidth"].$refs["VueCarousel-wrapper"]
+      wrapper.style.padding = "0 30px"
+      wrapper.style.boxSizing = "border-box"
+    },
+    render: h => {
+      return createContainer(
+        h, containerWidth, [h(Carousel, {
+          ref: "customWidth",
+        }, [new Array(8).fill(0).map((item, index) => {
+          return h(Slide, {
+            style: {
+              padding: "0 10px",
+              boxSizing: "border-box"
+            }
+          }, [h("div", {
+            style: {
+              width: "100%",
+              height: "400px",
+              lineHeight: "400px",
+              color: "#fff",
+              textAlign: "center",
+              fontSize: "30px",
+              backgroundColor: (index % 2 === 0) ? "#42b983" : "#ff3c3c"
+            }
+          }, [index])])
+        })])]
+      )
+    }
+  })
+

--- a/src/Carousel.vue
+++ b/src/Carousel.vue
@@ -2,6 +2,7 @@
   <section class="VueCarousel" >
     <div class="VueCarousel-wrapper" ref="VueCarousel-wrapper">
       <div
+        ref="VueCarousel-inner"
         class="VueCarousel-inner"
         role="listbox"
         v-bind:style="`
@@ -398,7 +399,8 @@ export default {
      * @return {Number} Width of the carousel in pixels
      */
     getCarouselWidth() {
-      this.carouselWidth = (this.$el && this.$el.clientWidth) || 0; // Assign globally
+      const inner = this.$refs["VueCarousel-inner"];
+      this.carouselWidth = (inner && inner.clientWidth) || 0; // Assign globally
       return this.carouselWidth;
     },
     /**

--- a/src/Carousel.vue
+++ b/src/Carousel.vue
@@ -290,8 +290,17 @@ export default {
     isHidden() {
       return this.carouselWidth <= 0;
     },
+    /**
+     * Maximum offset the carousel can slide
+     * Considering the spacePadding
+     * @return {Number}
+     */
     maxOffset() {
-      return this.slideWidth * this.slideCount - this.carouselWidth;
+      return (
+        this.slideWidth * this.slideCount -
+        this.carouselWidth +
+        this.spacePadding * 2
+      );
     },
     /**
      * Calculate the number of pages of slides


### PR DESCRIPTION
methods `getCarouselWidth` should get the width of `VueCarousel-inner`, since if we slide a page, we're supposed to translate the width of a single page, rather than the width of `VueCarousel-wrapper`.
And what's more, this helps us to meet the needs related in [#163](https://github.com/SSENSE/vue-carousel/issues/163) with some css tricks, which I have provided a demo in vue-play.