### PR TITLE
Fix passive event listener

### DIFF
--- a/src/Carousel.vue
+++ b/src/Carousel.vue
@@ -1,8 +1,8 @@
 <template>
   <section class="VueCarousel">
-    <div class="VueCarousel-wrapper" ref="VueCarousel-wrapper">
-      <div
-        ref="VueCarousel-inner"
+    <div class="VueCarousel-wrapper"
+      ref="VueCarousel-wrapper">
+      <div ref="VueCarousel-inner"
         class="VueCarousel-inner"
         role="listbox"
         :style="{
@@ -18,17 +18,13 @@
         <slot></slot>
       </div>
     </div>
-    <pagination
-      v-if="paginationEnabled && pageCount > 0"
-      @paginationclick="goToPage($event, 'pagination')"
-    ></pagination>
-    <navigation
-      v-if="navigationEnabled"
+    <pagination v-if="paginationEnabled && pageCount > 0"
+      @paginationclick="goToPage($event, 'pagination')"></pagination>
+    <navigation v-if="navigationEnabled"
       :clickTargetSize="navigationClickTargetSize"
       :nextLabel="navigationNextLabel"
       :prevLabel="navigationPrevLabel"
-      @navigationclick="handleNavigation"
-    ></navigation>
+      @navigationclick="handleNavigation"></navigation>
   </section>
 </template>
 <script>
@@ -470,13 +466,19 @@ export default {
       document.addEventListener(
         this.isTouch ? "touchend" : "mouseup",
         this.onEnd,
-        true
+        {
+          passive: false,
+          capture: true
+        }
       );
 
       document.addEventListener(
         this.isTouch ? "touchmove" : "mousemove",
         this.onDrag,
-        true
+        {
+          passive: false,
+          capture: true
+        }
       );
 
       this.startTime = e.timeStamp;
@@ -516,12 +518,18 @@ export default {
       document.removeEventListener(
         this.isTouch ? "touchend" : "mouseup",
         this.onEnd,
-        true
+        {
+          passive: false,
+          capture: true
+        }
       );
       document.removeEventListener(
         this.isTouch ? "touchmove" : "mousemove",
         this.onDrag,
-        true
+        {
+          passive: false,
+          capture: true
+        }
       );
     },
     /**

--- a/src/Carousel.vue
+++ b/src/Carousel.vue
@@ -7,7 +7,7 @@
         role="listbox"
         :style="{
           'transform': `translate3d(${currentOffset}px, 0, 0)`,
-          'transition': !dragging ? transitionStyle : 'none',
+          'transition': dragging ? 'none' : transitionStyle,
           'ms-flex-preferred-size': `${slideWidth}px`,
           'webkit-flex-basis': `${slideWidth}px`,
           'flex-basis': `${slideWidth}px`,

--- a/src/Slide.vue
+++ b/src/Slide.vue
@@ -47,7 +47,7 @@ export default {
     },
     /**
      * `isActive` describes whether a slide is visible
-     * @return {Boolean} [description]
+     * @return {Boolean}
      */
     isActive() {
       return this.activeSlides.includes(this._uid);
@@ -60,10 +60,7 @@ export default {
     isCenter() {
       const { perPage } = this.carousel;
       if (perPage % 2 === 0 || !this.isActive) return false;
-      return (
-        this.activeSlides.indexOf(this._uid) ===
-        Math.floor(this.carousel.perPage / 2)
-      );
+      return this.activeSlides.indexOf(this._uid) === Math.floor(perPage / 2);
     }
   }
 };


### PR DESCRIPTION
Set `passive` option to `false` when listen `touch` events on document, because maybe we want to prevent default event like link with `<a>`. Chrome 56+ sets `passive` to `true` by default.