### PR TITLE
fix: highlight multiple dots when scrollPerPage is set to false

### DIFF
--- a/src/Pagination.vue
+++ b/src/Pagination.vue
@@ -55,7 +55,10 @@ export default {
      * @return {boolean}
      */
     isCurrentDot(index) {
-      return index === this.carousel.currentPage;
+      const { currentPage, scrollPerPage, perPage } = this.carousel;
+      return scrollPerPage
+        ? index <= currentPage && index > currentPage - 1
+        : index < currentPage + perPage && index >= currentPage;
     }
   }
 };


### PR DESCRIPTION
This is another solution for issue #178 , in this case, we highlight multiple dots with config `{scrollPerPage : false, perPage: 2 // as long as perPage is bigger than 1}`.