### PR TITLE
Fix: Slide-click isTouch reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,11 @@ export default {
 | navigateTo                | Number  | 0       | Listen for an external navigation request using this prop.                                                                                                                                                                                                                            |
 | spacePadding              | Number  | 0       | Stage padding option adds left and right padding style (in pixels) onto VueCarousel-inner.                                                                                                                                                                                            |
 
+### Events
+| Event                     | Type    | Emitter  | Description                                                                                                                                                                                                                                                                           |
+|:--------------------------|:--------|:---------|:--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| slideClick                | Object  | Slide    | "slideClick" event throws the *dataset* object of the selected element                                                                                                                                                                                                          |
+
 ### HTML Structure
 
 Once the **Carousel** and **Slide** components are installed globally or imported, they can be used in templates in the following manner:

--- a/README.md
+++ b/README.md
@@ -103,6 +103,24 @@ Once the **Carousel** and **Slide** components are installed globally or importe
   </carousel>
 ```
 
+To listen for the 'slideClick' event you can do the following:
+
+``` html
+  <carousel>
+    <slide
+        data-index="0"
+        data-name="MySlideName"
+        @slideClick="handleSlideClick">
+      Slide 1 Content
+    </slide>
+    ...
+  </carousel>
+```
+```
+  handleSlideClick (dataset) => {
+    console.log(dataset.index, dataset.name)
+  }
+```
 ## Development
 
 A sandboxed dev environment is provided by [vue-play](https://github.com/vue-play/vue-play). Changes made to the component files will appear in real time in the sandbox. 

--- a/src/Slide.vue
+++ b/src/Slide.vue
@@ -26,7 +26,7 @@ export default {
     }
 
     this.$el.addEventListener(
-      this.isTouch ? "touchend" : "mouseup",
+      this.carousel.isTouch ? "touchend" : "mouseup",
       this.onTouchEnd
     );
   },


### PR DESCRIPTION
### Note ###
This is a documentation improve that get the fix line made by @JeanBarriere [here](https://github.com/SSENSE/vue-carousel/pull/185)

### Details ###
- Updated documentation to show how to use the event

