### PR TITLE
Add IE11 support

### DIFF
--- a/src/Carousel.vue
+++ b/src/Carousel.vue
@@ -6,7 +6,7 @@
         class="VueCarousel-inner"
         role="listbox"
         :style="{
-          'transform': `translate3d(${currentOffset}px, 0, 0)`,
+          'transform': `translate(${currentOffset}px, 0)`,
           'transition': dragging ? 'none' : transitionStyle,
           'ms-flex-preferred-size': `${slideWidth}px`,
           'webkit-flex-basis': `${slideWidth}px`,


### PR DESCRIPTION
Modern browsers are able to use native GPU acceleration, even without using translate3D.