### PR TITLE
Bug fix: Wrong max offset calculations

### DIFF
--- a/src/Carousel.vue
+++ b/src/Carousel.vue
@@ -325,11 +325,7 @@ export default {
      * @return {Number}
      */
     maxOffset() {
-      return (
-        this.slideWidth * (this.slideCount - 1) -
-        this.carouselWidth +
-        this.spacePadding * 2
-      );
+      return this.slideWidth * (this.slideCount - 1) - this.spacePadding * 2;
     },
     /**
      * Calculate the number of pages of slides

--- a/tests/client/components/carousel.spec.js
+++ b/tests/client/components/carousel.spec.js
@@ -116,6 +116,26 @@ describe('Carousel', () => {
     }, 2000)
   });
 
+  it('should go to second slide when we have odd number of slides and recompute carousel width', () => {
+    const vm = new Vue({
+      el: document.createElement('div'),
+      render: (h) => h(Carousel, {props: { scrollPerPage: true, perPage: 2}},
+        [h(Slide), h(Slide), h(Slide), h(Slide), h(Slide)]
+      ),
+    });
+    const carouselInstance = vm.$children[0];
+    carouselInstance.carouselWidth = 500;
+
+    return carouselInstance.$nextTick().then(() => {
+      carouselInstance.goToPage(1);
+      carouselInstance.computeCarouselWidth();
+
+      expect(carouselInstance.currentPage).toBe(1);
+
+      return Promise.resolve();
+    });
+  });
+
   it('should register 0 slides when 0 slides are added to the slots', () => {
     const vm = new Vue({
       el: document.createElement('div'),


### PR DESCRIPTION
I am not sure which issue I solved, but I think this one https://github.com/SSENSE/vue-carousel/issues/178

Steps to reproduce:

1. Configuration: `{ scrollPerPage: true, perPage: 2}`
2. Number of slides is 5
3. Click on first dot, if we are not on the first page
4. Click on second dot

Expected: Activating of second dot
Actual: Third dot is activated. Also, we cannot see 5th slide on carousel.