### PR TITLE
bug(carousel): fix navigateTo is not working as expected

### DIFF
--- a/src/Carousel.vue
+++ b/src/Carousel.vue
@@ -251,8 +251,15 @@ export default {
   },
 
   watch: {
-    navigateTo(val) {
-      if (val !== this.currentPage) this.goToPage(val);
+    navigateTo: {
+      immediate: true,
+      handler(val) {
+        if (val !== this.currentPage) {
+          this.$nextTick(() => {
+            this.goToPage(val);
+          });
+        }
+      }
     },
     currentPage(val) {
       this.$emit("pageChange", val);

--- a/src/Pagination.vue
+++ b/src/Pagination.vue
@@ -37,7 +37,6 @@ export default {
   inject: ["carousel"],
   computed: {
     pagniationCount() {
-      console.log(this.carousel.scrollPerPage);
       return this.carousel.scrollPerPage
         ? this.carousel.pageCount
         : this.carousel.slideCount - 2;


### PR DESCRIPTION
Ref to issue #220 

I also face wrong `maxOffset` caused `navigateTo` broken in ver 0.81, but I found another PR #221 solved the offset problem