### PR TITLE
Add space padding factor number to manage the last slide

### DIFF
--- a/src/Carousel.vue
+++ b/src/Carousel.vue
@@ -254,6 +254,13 @@ export default {
     spacePadding: {
       type: Number,
       default: 0
+    },
+    /**
+     *  Specify by how much should the space padding value be multiplied of, to re-arange the final slide padding.
+     */
+    spacePaddingMaxOffsetFactor: {
+      type: Number,
+      default: 0
     }
   },
 
@@ -346,7 +353,7 @@ export default {
     maxOffset() {
       return (
         this.slideWidth * (this.slideCount - this.currentPerPage) -
-        this.spacePadding * 2
+        this.spacePadding * this.spacePaddingMaxOffsetFactor
       );
     },
     /**


### PR DESCRIPTION
Add a factor number to the space padding multiplication, to handle how the last slide is rendered.
Currently, the `last slide` is cropped by the `inner` div and is not fully visible.

![capture d ecran 2018-08-13 a 16 51 21](https://user-images.githubusercontent.com/2766008/44039322-27b7fac4-9f19-11e8-9d6e-a75b38862c37.png)

By specifying `spacePaddingMaxOffsetFactor` to 0, 1 or 2, you can tweak how is rendered the last slide.
By setting to 0, the slide is positionned to the center.
By setting to 1, the slide is aligned to the right.
And by setting to 2 (the current behavior), we have the overflow case (see the screenshot).