### PR TITLE
Accessibility: Button tags must have textual content.

### DIFF
--- a/src/Pagination.vue
+++ b/src/Pagination.vue
@@ -18,6 +18,8 @@
         <button
           type="button"
           role="button"
+          aria-label="`Item ${index}`"
+          :title="`Item ${index}`"
           class="VueCarousel-dot-button"
           :tabindex="index"
           :style="`


### PR DESCRIPTION
Accessibility fix for pagination buttons not having title or aria-label