### PR TITLE
Emit when carousel is mounted

### DIFF
--- a/src/Carousel.vue
+++ b/src/Carousel.vue
@@ -687,6 +687,8 @@ export default {
       this.transitionend,
       this.handleTransitionEnd
     );
+
+    this.$emit("mounted");
   },
   beforeDestroy() {
     this.detachMutationObserver();


### PR DESCRIPTION
Hi,

When the carousel is loaded, I want to navigate to a certain page number.

I can change the "navigateTo", but only when the carousel is loaded. And I don't know when the carousel is actually loaded (I'm using SSR)

With this emit, a parent component can know if the Carousel is done loading