### PR TITLE
Improvement: #184

### DIFF
--- a/src/Carousel.vue
+++ b/src/Carousel.vue
@@ -596,6 +596,11 @@ export default {
      */
 
     onEnd(e) {
+      // restart autoplay if specified
+      if (this.autoplay && !this.autoplayHoverPause) {
+        this.restartAutoplay();
+      }
+
       // compute the momemtum speed
       const eventPosX = this.isTouch ? e.changedTouches[0].clientX : e.clientX;
       const deltaX = this.dragStartX - eventPosX;


### PR DESCRIPTION
The previous solution didn't work when manually switching slides using touch. Called restartAutoplay from the function onEnd. Tested on Vue-play. If you think there's a better place to call restartAutoplay lemme know. @quinnlangille 