### PR TITLE
feat(render): Add slots to allow custom navigation and pagination

### DIFF
--- a/docs/source/api/index.md
+++ b/docs/source/api/index.md
@@ -169,3 +169,27 @@ Stage padding option adds left and right padding style (in pixels) onto VueCarou
 * **Type**: `Number`
 * **Default**: `0`
 
+## Custom Pagination & Navigation
+
+Use named slots to render pagination and navigation using components.
+
+``` html
+  <carousel>
+    <slide>
+      Slide 1 Content
+    </slide>
+    <slide>
+      Slide 2 Content
+    </slide>
+
+    <numbered-pagination slot="pagination" />
+    <stylish-navigation slot="navigation" />
+  </carousel>
+```
+
+Your components can access the `carousel` provider by adding the following to you component configuration:
+
+```js
+	name: "numbered-pagination",
+	inject: ["carousel"]
+```

--- a/src/Carousel.vue
+++ b/src/Carousel.vue
@@ -26,18 +26,19 @@
       </div>
     </div>
 
-    <pagination 
-      v-if="paginationEnabled"
-      @paginationclick="goToPage($event, 'pagination')"
-    />
+    <slot name="pagination" v-if="paginationEnabled">
+      <pagination @paginationclick="goToPage($event, 'pagination')"/>
+    </slot>
 
-    <navigation 
-      v-if="navigationEnabled && isNavigationRequired"
-      :clickTargetSize="navigationClickTargetSize"
-      :nextLabel="navigationNextLabel"
-      :prevLabel="navigationPrevLabel"
-      @navigationclick="handleNavigation"
-    />
+    <slot name="navigation" v-if="navigationEnabled">
+      <navigation
+        v-if="isNavigationRequired"
+        :clickTargetSize="navigationClickTargetSize"
+        :nextLabel="navigationNextLabel"
+        :prevLabel="navigationPrevLabel"
+        @navigationclick="handleNavigation"
+      />
+    </slot>
   </section>
 </template>
 <script>


### PR DESCRIPTION
Allow custom components to be used for rendering pagination and navigation, with access to the `carousel` provider.

The following named slots have been added:
  1. `pagination`
  2. `navigation`

```html
<carousel>
  <slide>content</slide>
  <custom-pagination slot="pagination" />
  <custom-navigation slot="navigation" />
</carousel>
```

## Description
The pagination and navigation included in `vue-carousel` is somewhat limited. Adding named slots to allow custom components to be used to render these elements adds more flexibility without impacting the default usage. Without slots, its not possible for custom components to access the `carousel` provider.

## Motivation and Context
To allow for more custom rendering of navigation and pagination elements.

## How Has This Been Tested?
Using vue-play in the browser. This is a very simple change, it should not impact the current default behavior.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] My code follows the code style of this project.
- [ x] My change requires a change to the documentation.
  - [ x] I have updated the documentation accordingly.
- [ ] I have included a vue-play example (if this is a new feature)

I haven't added an example to vue-play, the default `pagination` and `navigation` components already verify the feature is working correctly.
