### PR TITLE
docs(readme): updated README configuration section

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,9 @@ export default {
 ### Configuration
 | Property                  | Type    | Default | Description                                                                                                                                                                                                                                                                           |
 |:--------------------------|:--------|:--------|:--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| autoplay                  | Boolean | false   | Flag to enable autoplay           
+| autoplayTimeout           | Number  | 2000    | Time elapsed before advancing slide     
+| autoplayHoverPause        | Boolean | false   | Flag to pause autoplay on hover
 | easing                    | String  | ease    | Slide transition easing. Any valid CSS transition easing accepted.                                                                                                                                                                                                                    |
 | minSwipeDistance          | Number  | 8       | Minimum distance for the swipe to trigger a slide advance.                                                                                                                                                                                                                            |
 | navigationClickTargetSize | Number  | 8       | Amount of padding to apply around the label in pixels.                                                                                                                                                                                                                                |


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Added the missing properties to the repo's `README.md`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
3 properties were missing from the `README.md` file but were available on the official [API docs](https://ssense.github.io/vue-carousel/api/).  
Mentioned in #196.