### PR TITLE
Allows custom width for carousel

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ export default {
 | autoplay                  | Boolean | false   | Flag to enable autoplay           
 | autoplayTimeout           | Number  | 2000    | Time elapsed before advancing slide     
 | autoplayHoverPause        | Boolean | false   | Flag to pause autoplay on hover
+| customSlideWidth          | Number  | 0       | Sets custom width for carousel and slides
 | easing                    | String  | ease    | Slide transition easing. Any valid CSS transition easing accepted.                                                                                                                                                                                                                    |
 | minSwipeDistance          | Number  | 8       | Minimum distance for the swipe to trigger a slide advance.                                                                                                                                                                                                                            |
 | navigationClickTargetSize | Number  | 8       | Amount of padding to apply around the label in pixels.                                                                                                                                                                                                                                |

--- a/docs/source/api/index.md
+++ b/docs/source/api/index.md
@@ -25,6 +25,13 @@ Flag to pause autoplay on hover
 * **Type**: `Boolean`
 * **Default**: `true`
 
+### customSlideWidth
+
+Sets custom width for the carousel.
+
+* **Type**: `Number`
+* **Default**: `0`
+
 ### loop
 
 Flag to make the carousel loop (wrap) when it reaches either end.

--- a/play/index.js
+++ b/play/index.js
@@ -369,4 +369,25 @@ play("Carousel", module)
         slides: images
       }
     }
+	})
+	.add("With customSlideWidth", {
+    template:
+      `<div style="width: 100%; display: flex; justify-content: center; margin-top: 40px;">
+        <carousel :custom-slide-width="450" :adjustableHeight="true" :navigationEnabled="true" :perPage="1">
+          <slide v-for="(slide, idx) in slides">
+            <div style="width: 300px; margin: auto">
+              <img style="display: block; height: 300px; margin-left: auto; margin-right: auto" :src="slide" />
+            </div>
+          </slide>
+        </carousel>
+      </div>`,
+    components: {
+      Carousel,
+      Slide
+    },
+    data() {
+      return {
+        slides: images
+      }
+    }
   })

--- a/src/Carousel.vue
+++ b/src/Carousel.vue
@@ -1,5 +1,9 @@
 <template>
-  <section class="VueCarousel">
+  <section
+		class="VueCarousel"
+		:style="{
+			'width': customSlideWidth ? `${customSlideWidth}px` : '100%'
+		}">
     <div 
       class="VueCarousel-wrapper"
       ref="VueCarousel-wrapper"
@@ -113,6 +117,13 @@ export default {
     };
   },
   props: {
+    /**
+     * Sets a custom width for the carousel and slides
+     */
+    customSlideWidth: {
+      type: Number,
+      default: 0
+    },
     /**
      * Support for v-model functionality
      */
@@ -569,6 +580,10 @@ export default {
      * @return {Number} Width of the carousel in pixels
      */
     getCarouselWidth() {
+      if (this.customSlideWidth > 0) {
+        this.carouselWidth = this.customSlideWidth;
+        return this.customSlideWidth;
+      }
       let carouselInnerElements = this.$el.getElementsByClassName(
         "VueCarousel-inner"
       );

--- a/tests/client/components/__snapshots__/carousel.spec.js.snap
+++ b/tests/client/components/__snapshots__/carousel.spec.js.snap
@@ -271,6 +271,22 @@ exports[`Carousel should set carousel height to slide height 1`] = `
 "
 `;
 
+exports[`Carousel should set custom carousel width 1`] = `
+".VueCarousel-wrapper
+  .VueCarousel-inner(role='listbox', style='transform: translate(0px, 0); visibility: visible; height: auto;')
+    .VueCarousel-slide(tabindex='-1')
+    .VueCarousel-slide(tabindex='-1')
+|  
+.VueCarousel-pagination(style='')
+  ul.VueCarousel-dot-container(role='tablist')
+    li.VueCarousel-dot.VueCarousel-dot--active(aria-hidden='false', role='presentation', aria-selected='true', style='margin-top: 20px; padding: 10px;')
+      button.VueCarousel-dot-button(type='button', role='button', aria-label='\`Item \${index}\`', title='Item 0', tabindex='0', style='width: 10px; height: 10px; background: rgb(0, 0, 0);')
+    li.VueCarousel-dot(aria-hidden='false', role='presentation', aria-selected='false', style='margin-top: 20px; padding: 10px;')
+      button.VueCarousel-dot-button(type='button', role='button', aria-label='\`Item \${index}\`', title='Item 1', tabindex='0', style='width: 10px; height: 10px; background: rgb(239, 239, 239);')
+// 
+"
+`;
+
 exports[`Carousel should unmount successfully 1`] = `
 ".VueCarousel-wrapper
   .VueCarousel-inner(role='listbox', style='transform: translate(0px, 0); visibility: hidden; height: auto;')

--- a/tests/client/components/carousel.spec.js
+++ b/tests/client/components/carousel.spec.js
@@ -318,5 +318,17 @@ describe('Carousel', () => {
         utils.expectToMatchSnapshot(vm);
         done();
       })
+	});
+	
+	it('should set custom carousel width', () => {
+    const vm = new Vue({
+      el: document.createElement('div'),
+      render: (h) => h(Carousel, { props: { perPage: 1, customSlideWidth: 500 } }, [h(Slide), h(Slide)]),
+    });
+
+		const carouselInstance = vm.$children[0];
+		expect(carouselInstance.carouselWidth).toBe(500);
+		expect(carouselInstance.customSlideWidth).toBe(500);
+    return utils.expectToMatchSnapshot(vm);
   });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Request was made to allow user to provide a `customSlideWidth` prop to `Carousel.vue`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Feature request here: https://github.com/SSENSE/vue-carousel/issues/294

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Added a test case to `carousel.spec.js`. All snapshots needed to be updated due to the inline styling for the `Carousel` component.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/347483/47766167-c3597580-dca3-11e8-97d9-dd9ba4c0325a.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have included a vue-play example (if this is a new feature)
