### PR TITLE
Fix fake news in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ export default {
 |:--------------------------|:--------|:--------|:--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | autoplay                  | Boolean | false   | Flag to enable autoplay           
 | autoplayTimeout           | Number  | 2000    | Time elapsed before advancing slide     
-| autoplayHoverPause        | Boolean | false   | Flag to pause autoplay on hover
+| autoplayHoverPause        | Boolean | true   | Flag to pause autoplay on hover
 | easing                    | String  | ease    | Slide transition easing. Any valid CSS transition easing accepted.                                                                                                                                                                                                                    |
 | minSwipeDistance          | Number  | 8       | Minimum distance for the swipe to trigger a slide advance.                                                                                                                                                                                                                            |
 | navigationClickTargetSize | Number  | 8       | Amount of padding to apply around the label in pixels.                                                                                                                                                                                                                                |


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
The README says `autoHoverPause`'s default is `false`, but it's actually `true`. 

![fake news](https://media.giphy.com/media/3ohzdJeMka5heqSbZu/200w_d.gif)

## Description
Changed the default val for the attr to the correct val.

## Motivation and Context
Acurrate readme.. 

## How Has This Been Tested?
n/a



## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
  - [x] I have updated the documentation accordingly.
- [ ] I have included a vue-play example (if this is a new feature)
