### PR TITLE
Add correct calculation for pageCount when using scrollPerPage false

### DIFF
--- a/src/Carousel.vue
+++ b/src/Carousel.vue
@@ -418,7 +418,7 @@ export default {
     pageCount() {
       return this.scrollPerPage
         ? Math.ceil(this.slideCount / this.currentPerPage)
-        : this.slideCount - 2;
+        : this.slideCount - this.currentPerPage + 1;
     },
     /**
      * Calculate the width of each slide

--- a/src/Pagination.vue
+++ b/src/Pagination.vue
@@ -41,8 +41,8 @@ export default {
     paginationCount() {
       return this.carousel && this.carousel.scrollPerPage
         ? this.carousel.pageCount
-        : this.carousel.slideCount
-          ? this.carousel.slideCount - 2
+        : this.carousel.slideCount && this.carousel.currentPerPage
+          ? this.carousel.slideCount - this.carousel.currentPerPage + 1
           : 0;
     }
   },

--- a/tests/client/components/__snapshots__/carousel.spec.js.snap
+++ b/tests/client/components/__snapshots__/carousel.spec.js.snap
@@ -86,6 +86,10 @@ exports[`Carousel should decrease current slide number by 1 when advance slide b
       button.VueCarousel-dot-button(type='button', role='button', aria-label='\`Item \${index}\`', title='Item 0', tabindex='0', style='width: 10px; height: 10px; background: rgb(239, 239, 239);')
     li.VueCarousel-dot.VueCarousel-dot--active(aria-hidden='false', role='presentation', aria-selected='true', style='margin-top: 20px; padding: 10px;')
       button.VueCarousel-dot-button(type='button', role='button', aria-label='\`Item \${index}\`', title='Item 1', tabindex='0', style='width: 10px; height: 10px; background: rgb(0, 0, 0);')
+    li.VueCarousel-dot(aria-hidden='false', role='presentation', aria-selected='false', style='margin-top: 20px; padding: 10px;')
+      button.VueCarousel-dot-button(type='button', role='button', aria-label='\`Item \${index}\`', title='Item 2', tabindex='0', style='width: 10px; height: 10px; background: rgb(239, 239, 239);')
+    li.VueCarousel-dot(aria-hidden='false', role='presentation', aria-selected='false', style='margin-top: 20px; padding: 10px;')
+      button.VueCarousel-dot-button(type='button', role='button', aria-label='\`Item \${index}\`', title='Item 3', tabindex='0', style='width: 10px; height: 10px; background: rgb(239, 239, 239);')
 // 
 "
 `;


### PR DESCRIPTION
## Description
Updated the page count calculation for the carousel and pagination to properly display the correct number of pagination dots for scrollPerPage false

## Motivation and Context
The current functionality is broken and very apparent when using scrollPerPage in vue play

## How Has This Been Tested?
I have only tested the implementation in vue play

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] I have included a vue-play example (if this is a new feature)
