### PR TITLE
fix(carousel): calculation lastFullPageOffset

### DIFF
--- a/src/Carousel.vue
+++ b/src/Carousel.vue
@@ -774,7 +774,7 @@ export default {
 
       // lock offset to either the nearest page, or to the last slide
       const lastFullPageOffset =
-        width * Math.floor(this.slideCount / this.currentPerPage - 1);
+        width * Math.floor(this.slideCount / (this.currentPerPage - 1));
       const remainderOffset =
         lastFullPageOffset +
         this.slideWidth * (this.slideCount % this.currentPerPage);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
It is not possible to reach the last slide by using swipe when navigation is enabled

## Description
Before 0.16.0, it was not possible to reach the last slide by using navigation "next" button. Swiping everything worked fine. After update to 0.16.0, this behavor is inverted, i.e., I can reach the last slider by pressing "next" button but not by swiping. 
This Pull Request fixes a calculation issue that was creating this unexpected behavior.

## Motivation and Context
Fixes issue https://github.com/SSENSE/vue-carousel/issues/345

## How Has This Been Tested?
There is already a Vue Play case for this in the project, and was also tested manually in all VuePlay cases

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] I have included a vue-play example (if this is a new feature)
