### PR TITLE
feat(carousel): use passive event listener to improve scrolling performance

### DIFF
--- a/src/Carousel.vue
+++ b/src/Carousel.vue
@@ -47,6 +47,7 @@
 <script>
 import autoplay from "./mixins/autoplay";
 import debounce from "./utils/debounce";
+import supportsPassive from "./utils/support-passive";
 import Navigation from "./Navigation.vue";
 import Pagination from "./Pagination.vue";
 import Slide from "./Slide.vue";
@@ -926,7 +927,8 @@ export default {
     if ((this.isTouch && this.touchDrag) || this.mouseDrag) {
       this.$refs["VueCarousel-wrapper"].addEventListener(
         this.isTouch ? "touchstart" : "mousedown",
-        this.onStart
+        this.onStart,
+        supportsPassive() ? { passive: true } : false
       );
     }
 

--- a/src/utils/support-passive.js
+++ b/src/utils/support-passive.js
@@ -1,0 +1,13 @@
+export default function supportsPassive() {
+  let supported = false;
+  try {
+    var opts = Object.defineProperty({}, "passive", {
+      get: function() {
+        supported = true;
+      }
+    });
+    window.addEventListener("testPassive", null, opts);
+    window.removeEventListener("testPassive", null, opts);
+  } catch (e) {}
+  return supported;
+}


### PR DESCRIPTION
Use passive event listener to improve scrolling performance

## Description
Added `{ passive: true }` to touchstart event listener

## Motivation and Context
https://developers.google.com/web/tools/lighthouse/audits/passive-event-listeners

## How Has This Been Tested?
Using the new build from this branch, lighthouse audit's result is clear from `Does not use passive listeners to improve scrolling performance`

## Types of changes
- [x] Refactor touchstart event listener, added `passive: true` options

## Checklist:
- [x] My code follows the code style of this project.
