### PR TITLE
feat(event): add keypress listener to control carousel navigation

### DIFF
--- a/play/index.js
+++ b/play/index.js
@@ -682,3 +682,27 @@ play("Carousel", module)
       }
     }
   })
+  .add("Navigation-key event", {
+    template:
+      `<div style="width: 100%; display: flex; justify-content: center; margin-top: 40px;">
+        <carousel style="width: 500px;" @navigation-click="onKeypressNavigation">
+          <slide v-for="slide in slides" :key="slide">
+            <img style="width: 100%;" :src="slide" />
+          </slide>
+        </carousel>
+      </div>`,
+    components: {
+      Carousel,
+      Slide
+    },
+    data() {
+      return {
+        slides: images
+      }
+    },
+    methods: {
+      onKeypressNavigation(direction) {
+        this.$log(`Captured [navigation-key] event. Current direction is ${direction}`)
+      },
+    }
+})

--- a/src/Carousel.vue
+++ b/src/Carousel.vue
@@ -47,6 +47,7 @@
 <script>
 import autoplay from "./mixins/autoplay";
 import debounce from "./utils/debounce";
+import keypressNavigation from "./mixins/keypressNavigation";
 import Navigation from "./Navigation.vue";
 import Pagination from "./Pagination.vue";
 import Slide from "./Slide.vue";
@@ -107,7 +108,7 @@ export default {
       currentHeight: "auto"
     };
   },
-  mixins: [autoplay],
+  mixins: [autoplay, keypressNavigation],
   // use `provide` to avoid `Slide` being nested with other components
   provide() {
     return {

--- a/src/mixins/keypressNavigation.js
+++ b/src/mixins/keypressNavigation.js
@@ -1,0 +1,31 @@
+const keypressNavigation = {
+  created() {
+    window.addEventListener("keydown", this.keypressNavigation);
+  },
+  beforeDestroy() {
+    window.removeEventListener("keydown", this.keypressNavigation);
+  },
+  methods: {
+    keypressNavigation(e) {
+      if (e.keyCode == "37") {
+        e.preventDefault();
+
+        let direction = "backward";
+
+        this.advancePage(direction);
+        this.$emit("navigation-click", direction);
+      }
+
+      if (e.keyCode == "39") {
+        e.preventDefault();
+
+        let direction = "forward";
+
+        this.advancePage(direction);
+        this.$emit("navigation-click", direction);
+      }
+    }
+  }
+};
+
+export default keypressNavigation;


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->
Added keypress event listener to control carousel navigation.

## Description
Created a mixin file that would add a keypress listener, listening for 39(right-arrow) & 37(left-arrow) keys, after the instance is created and remove it before the instance is destroyed. 

## Motivation and Context
[Feature Request: #248](https://github.com/SSENSE/vue-carousel/issues/248)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
I imported the mixin file to the carousel component, ran `yarn dev` and tested the arrow keys to see if the carousel images would advance forward or backward.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x ] I have included a vue-play example (if this is a new feature)
