### PR TITLE
fix(carousel): remove resize listener

### DIFF
--- a/src/Carousel.vue
+++ b/src/Carousel.vue
@@ -914,14 +914,20 @@ export default {
     handleTransitionEnd() {
       this.$emit("transitionEnd");
       this.$emit("transition-end");
+    },
+    removeWindowEventListeners(eventType, ...handlers) {
+      handlers.forEach(handler =>
+              window.removeEventListener(eventType, handler)
+      );
     }
   },
   mounted() {
-    window.addEventListener(
-      "resize",
-      debounce(this.onResize, this.refreshRate)
+    this.debounceHandler = debounce(this.onResize, this.refreshRate);
+    this.removeWindowEventListeners(
+            "resize",
+            this.getBrowserWidth,
+            this.debounceHandler
     );
-
     // setup the start event only if touch device or mousedrag activated
     if ((this.isTouch && this.touchDrag) || this.mouseDrag) {
       this.$refs["VueCarousel-wrapper"].addEventListener(

--- a/tests/client/components/carousel.spec.js
+++ b/tests/client/components/carousel.spec.js
@@ -3,7 +3,7 @@
 import { mount, shallowMount } from '@vue/test-utils';
 import Carousel from '../../../src/Carousel.vue';
 import Slide  from '../../../src/Slide.vue';
- 
+
 describe('Carousel component', () => {
   describe('Default mounting properties', () => {
     it('should mount successfully', () => {
@@ -171,7 +171,7 @@ describe('Carousel component', () => {
       wrapper.vm.autoplayAdvancePage();
       expect(spy).toHaveBeenCalledWith('test');
 
-      spy.mockRestore(); 
+      spy.mockRestore();
       done()
     });
 
@@ -852,6 +852,16 @@ describe('Carousel component', () => {
       wrapper.vm.handleTransitionEnd();
 
       expect(wrapper.emitted().transitionEnd).toBeDefined();
+    });
+
+    it('should call removeEventListeners on destroy', () => {
+      const wrapper = mount(Carousel);
+
+      const carouselInstance = wrapper.vm;
+      const spy = jest.spyOn(carouselInstance, "removeWindowEventListeners");
+      carouselInstance.$destroy();
+
+      expect(spy).toHaveBeenCalled;
     });
   });
 


### PR DESCRIPTION
## Description
Removing handler from window on component destroy. Added helper method to remove events from the window to prevent repetition.

## Motivation and Context
[https://github.com/SSENSE/vue-carousel/issues/385](url)

## How Has This Been Tested?
Tested locally by observing handler events and via unit test.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] I have included a vue-play example (if this is a new feature)
