### PR TITLE
Add slidetouchend event on slide

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ export default {
 | `pagination-click`             |         | Carousel | Emits when a pagination button is clicked, with the current `pageNumber`                                                                                                                                                                                                                        |
 | `page-change`                 | Number  | Carousel | Emits with the current page number.                                                                                                                                                                                                                       |
 | `slide-click`                | Object  | Slide    | Emits with the *dataset* object of the selected element                        ··
+| `slide-touch-end`                | Object  | Slide    | Emits an object with the *dataset* object of the selected element, deltaX and deltaY of the gesture or mouse move
 | `transition-start` | | Carousel | Emits when the transition end is reached                                                                                                                                                  |
 | `transition-end`             |         | Carousel | Emits when the transition start is reached                                                                                                     ·                                                                                                               |
 

--- a/src/Slide.vue
+++ b/src/Slide.vue
@@ -88,13 +88,29 @@ export default {
       /**
        * @event slideclick
        * @event slide-click
+       * @event slidetouchend
+       * @event slide-touch-end
        * @type {Object}
        */
       const eventPosX =
         this.carousel.isTouch && e.changedTouches && e.changedTouches.length > 0
           ? e.changedTouches[0].clientX
           : e.clientX;
-      const deltaX = this.carousel.dragStartX - eventPosX;
+      const eventPosY =
+        this.carousel.isTouch && e.changedTouches && e.changedTouches.length > 0
+          ? e.changedTouches[0].clientY
+          : e.clientY;
+
+      const deltaX = eventPosX - this.carousel.dragStartX;
+      const deltaY = eventPosY - this.carousel.dragStartY;
+
+      var toucheEndData = {
+        dataset: Object.assign({}, e.currentTarget.dataset),
+        deltaX,
+        deltaY
+      };
+      this.$emit("slidetouchend", toucheEndData);
+      this.$emit("slide-touch-end", toucheEndData);
 
       if (
         this.carousel.minSwipeDistance === 0 ||

--- a/tests/client/components/slide.spec.js
+++ b/tests/client/components/slide.spec.js
@@ -10,6 +10,7 @@ describe('Slide', () => {
       isTouch: true,
       adjustableHeight: true,
       dragStartX: 0,
+      dragStartY: 15,
       minSwipeDistance: 10,
       perPage: 3,
       currentPage: 0,
@@ -120,7 +121,7 @@ describe('Slide', () => {
       expect(wrapper.emitted().slideclick[0][0]).toEqual({"foo": "dataset"});
     });
 
-    it('shoud not emit slideclick event', () => {
+    it('shoud not emit slideclick event if swipe on X is more than the carousel\'s minSwipeDistance', () => {
       const wrapper = shallowMount(Slide, {
         propsData: { title: 'fooTitle' },
         provide: { carousel }
@@ -129,6 +130,46 @@ describe('Slide', () => {
       wrapper.vm.onTouchEnd({ clientX: 11, currentTarget: { dataset: { foo: 'dataset' } } });
 
       expect(wrapper.emitted().slideclick).toBeUndefined();
+    });
+
+
+    it('should emit slidetoucheend event if carousel is isTouch', () => {
+      const wrapper = shallowMount(Slide, {
+        propsData: { title: 'fooTitle' },
+        provide: { carousel }
+      });
+
+      wrapper.vm.onTouchEnd({ changedTouches: [{ clientX: 9, clientY: 9 }], currentTarget: { dataset: { foo: 'dataset' } } });
+
+      expect(wrapper.emitted().slidetouchend[0][0].dataset).toEqual({ foo: 'dataset' });
+      expect(wrapper.emitted().slidetouchend[0][0].deltaY).toEqual(-6);
+      expect(wrapper.emitted().slidetouchend[0][0].deltaX).toEqual(9);
+    });
+
+    it('should emit slidetoucheend event if carousel is not isTouch', () => {
+      carousel.isTouch = false;
+
+      const wrapper = shallowMount(Slide, {
+        propsData: { title: 'fooTitle' },
+        provide: { carousel }
+      });
+
+      wrapper.vm.onTouchEnd({ clientX: 9, clientY: 9, currentTarget: { dataset: { foo: 'dataset' } } });
+
+      expect(wrapper.emitted().slidetouchend[0][0].dataset).toEqual({ foo: 'dataset' });
+      expect(wrapper.emitted().slidetouchend[0][0].deltaY).toEqual(-6);
+      expect(wrapper.emitted().slidetouchend[0][0].deltaX).toEqual(9);
+    });
+
+    it("shoud emit slidetoucheend event if swipe on X more than the carousel's minSwipeDistance", () => {
+      const wrapper = shallowMount(Slide, {
+        propsData: { title: 'fooTitle' },
+        provide: { carousel }
+      });
+
+      wrapper.vm.onTouchEnd({ clientX: 11, clientY: 9, currentTarget: { dataset: { foo: 'dataset' } }});
+
+      expect(wrapper.emitted().slidetouchend).toBeDefined();
     });
   });
 });


### PR DESCRIPTION
## Description

Add the slide-touch-end event on slide component to know when a touch end.

## Motivation and Context

We use your library to show content to our users.
We want to toggle a menu when a user click inside a slide and force to show the menu when he scrolls up.
Today, if user scrolls up, the library emit a slide-click. For our use case it's not enough.
Inside the slide component, you already know the horizontal distance of the user's gesture.
We have add the compute of the vertical distance, then we emit the two distances and the dataset on the new event.

## How Has This Been Tested?

Add unit test to ensure the behaviour and use it for our project.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
  - [x] I have updated the documentation accordingly.
- [ ] I have included a vue-play example (if this is a new feature)
