### PR TITLE
docs: fix scrollPerPage default value

### DIFF
--- a/docs/public/api/index.html
+++ b/docs/public/api/index.html
@@ -140,7 +140,7 @@
 <h3 id="scrollPerPage"><a href="#scrollPerPage" class="headerlink" title="scrollPerPage"></a>scrollPerPage</h3><p>Scroll per page, not per item.</p>
 <ul>
 <li><strong>Type</strong>: <code>Boolean</code></li>
-<li><strong>Default</strong>: <code>false</code></li>
+<li><strong>Default</strong>: <code>true</code></li>
 </ul>
 <h3 id="size"><a href="#size" class="headerlink" title="size"></a>size</h3><p>Size of each pagination dot. Pixel values are accepted.</p>
 <ul>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
fix `scrollPerPage` default value

## Description
<!--- Describe your changes in detail -->
https://github.com/SSENSE/vue-carousel/blob/master/src/Carousel.vue#L293-L296
I fixed docs because default value of scrollPerPage is true in this source code.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. --> 
issue is here https://github.com/SSENSE/vue-carousel/issues/494

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
  - [x] I have updated the documentation accordingly.
- [ ] I have included a vue-play example (if this is a new feature)
