### PR TITLE
fix detection of being touch device

### DIFF
--- a/src/Carousel.vue
+++ b/src/Carousel.vue
@@ -98,7 +98,9 @@ export default {
       dragOffset: 0,
       dragStartY: 0,
       dragStartX: 0,
-      isTouch: typeof window !== "undefined" && "ontouchstart" in window,
+      isTouch: (typeof window !== "undefined" && "ontouchstart" in window) ||  
+           ( navigator.maxTouchPoints > 0 ) ||  
+           ( navigator.msMaxTouchPoints > 0 ),
       offset: 0,
       refreshRate: 16,
       slideCount: 0,


### PR DESCRIPTION
The detection with checking if a specific handler is available in the window is not always working. This causes issues, that the carousel is working with the knowledge of having a non-touch device and does attach the wrong handlers.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
I don't know if there is already an issue for that, but it does exist the issue, that the carousel does not side on some Electron Apps using vue-carousel.

## How Has This Been Tested?
With an Electron App, where it was not working before. No additional testing required, because it's a known default for checking if it's a touch device.

https://www.geeksforgeeks.org/how-to-detect-touch-screen-device-using-javascript/

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
