### PR TITLE
IE nav button fix

### DIFF
--- a/src/Navigation.vue
+++ b/src/Navigation.vue
@@ -92,6 +92,7 @@ export default {
   padding: 0;
   cursor: pointer;
   outline: none;
+  z-index: 1000;
 }
 
 .VueCarousel-navigation-button:focus {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fixes the issue on IE, where pagination dots are overlapping navigation buttons, and in result there is 1px where user can actually click on buttons.

## Motivation and Context
UX improvement.

## How Has This Been Tested?
Has been tested only on browser since it's small, non-breaking cange.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] I have included a vue-play example (if this is a new feature)
