### PR TITLE
feat/#269 Added onMouseUp Event 

### DIFF
--- a/play/index.js
+++ b/play/index.js
@@ -272,6 +272,30 @@ play("Carousel", module)
       },
     }
   })
+  .add("non-touch slideclick event", {
+    template:
+      `<div style="width: 100%; display: flex; justify-content: center; margin-top: 40px;">
+        <carousel style="width: 500px;">
+          <slide v-for="slide in slides" :key="slide" @slideclick="onSlideClick">
+            <img style="width: 100%;" :src="slide" />
+          </slide>
+        </carousel>
+      </div>`,
+    components: {
+      Carousel,
+      Slide
+    },
+    data() {
+      return {
+        slides: images
+      }
+    },
+    methods: {
+      onSlideClick(currentDataset) {
+        this.$log(`Captured non touch slide click event. Current dataset is ${JSON.stringify(currentDataset)}`)
+      },
+    }
+  })
   .add("slideclick event", {
     template:
       `<div style="width: 100%; display: flex; justify-content: center; margin-top: 40px;">

--- a/src/Slide.vue
+++ b/src/Slide.vue
@@ -31,7 +31,8 @@ export default {
 
     this.$el.addEventListener(
       this.carousel.isTouch ? "touchend" : "mouseup",
-      this.onTouchEnd
+      this.onTouchEnd,
+      this.onMouseUp
     );
   },
   computed: {
@@ -99,6 +100,20 @@ export default {
       if (
         this.carousel.minSwipeDistance === 0 ||
         Math.abs(deltaX) < this.carousel.minSwipeDistance
+      ) {
+        this.$emit("slideclick", Object.assign({}, e.currentTarget.dataset));
+        this.$emit("slide-click", Object.assign({}, e.currentTarget.dataset));
+      }
+    },
+
+    onMouseUp(e) {
+      // On click for non-touch events only
+      const X_Axis_Pos = e.clientX;
+      const X_Axis_Change = this.carousel.dragStartX - X_Axis_Pos;
+
+      if (
+        this.carousel.minSwipeDistance === 0 ||
+        Math.abs(X_Axis_Change) < this.carousel.minSwipeDistance
       ) {
         this.$emit("slideclick", Object.assign({}, e.currentTarget.dataset));
         this.$emit("slide-click", Object.assign({}, e.currentTarget.dataset));


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adds feature requested in Issue #269. Added onMouseUp event for non-touch functionality. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Issue #269 
https://github.com/SSENSE/vue-carousel/issues/269
The requester wanted to emit separate events for touch and swipe, so this adds a touch and non-touch click with the onMouseUp.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Tested by using vue-play and thoroughly testing both on own instance of carousel as well as vue-play.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] I have included a vue-play example (if this is a new feature)
