### PR TITLE
Added custom navigation links

### DIFF
--- a/src/Carousel.vue
+++ b/src/Carousel.vue
@@ -136,6 +136,16 @@ export default {
       type: Boolean,
       default: false
     },
+
+    endOfCarouselLink: {
+      type: String,
+      default: null
+    },
+
+    beginningOfCarouselLink: {
+      type: String,
+      defualt: null
+    },
     /**
      * Slide transition easing
      * Any valid CSS transition easing accepted
@@ -540,12 +550,23 @@ export default {
     advancePage(direction) {
       if (direction && direction === "backward" && this.canAdvanceBackward) {
         this.goToPage(this.getPreviousPage(), "navigation");
+        this.$log("1");
       } else if (
         (!direction || (direction && direction !== "backward")) &&
         this.canAdvanceForward
       ) {
         this.goToPage(this.getNextPage(), "navigation");
+        this.$log("2");
       }
+      else if (direction && direction === "backward" && !this.canAdvanceBackward && this.beginningOfCarouselLink) {
+        this.$log("beginnning");
+        this.route(this.beginningOfCarouselLink);
+      }
+      else if (direction && direction === "forward" && !this.canAdvanceForward && this.endOfCarouselLink !== null) {
+        this.$log("end");
+        this.route(this.endOfCarouselLink);
+      }
+
     },
     goToLastSlide() {
       // following code is to disable animation
@@ -914,6 +935,9 @@ export default {
     handleTransitionEnd() {
       this.$emit("transitionEnd");
       this.$emit("transition-end");
+    },
+    route(link) {
+      window.location.href = link
     }
   },
   mounted() {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
I added two new props the the "Carousel" component: "endOfCarouselLink" and "beginningOfCarousel". The "endOfCarousel" prop takes a URL as an argument and redirects to that link when you try to scroll past the end of of the last slide in the carousel. Likewise, the "beginningOfCarousel" props takes a URL as an argument and redirects to that link when you try to navigate backwards when on the first slide. I modified the "advancePage" to handle the cases when you try to scroll past either end of the carousel and redirect to the appropriate link.

## Motivation and Context
https://github.com/SSENSE/vue-carousel/issues/294 

## How Has This Been Tested?
This was tested by hand using vue-play to make sure the changes work and do not break the current functionality of the carousel.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] I have included a vue-play example (if this is a new feature)
